### PR TITLE
fix: shift in encoding of itype instructions

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -81,7 +81,7 @@ impl IType {
 
         let immediate = sign_shrink(immediate, 12);
 
-        Self((((((((immediate << 5) + rs1) << 3) + funct3) << 5) + rd) << 5) + opcode)
+        Self((((((((immediate << 5) + rs1) << 3) + funct3) << 5) + rd) << 7) + opcode)
     }
     pub fn imm(&self) -> i32 {
         sign_extend(self.0 >> 20, 12) as i32


### PR DESCRIPTION
@danielkocher: This is the one-line fix I was mentioning earlier. I will commit this after your changes to avoid merge conflict. There is no rush with this one.