### PR TITLE
Improve compressed instruction support for selfie.

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -103,6 +103,7 @@ mod tests {
     #[test]
     fn test_quadrant1() {
         // C.NOP
+        assert_eq!(decode(0x0001).unwrap(), Addi(IType(0x00000013))); // addi a0, a0, 0
 
         // C.ADDI
         assert_eq!(decode(0x17e1).unwrap(), Addi(IType(0xff878793))); // addi a5, a5, -8

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -49,7 +49,7 @@ pub fn decompress_q2(i: u16) -> DecompressionResult {
         0b011 => decompress_load_sp(i, CiInstr::Ld),
         0b100 => decompress_jr_mv_add(i),
         0b101 => Err(DecodingError::Unimplemented), // C.FSDSP
-        0b110 => Err(DecodingError::Unimplemented), // C.SWSP
+        0b110 => decompress_store_sp(i, CsInstr::Sw),
         0b111 => decompress_store_sp(i, CsInstr::Sd),
         _ => unreachable!(),
     }
@@ -196,7 +196,8 @@ mod tests {
 
         // C.FSDSP unimplemented
 
-        // C.SWSP unimplemented
+        // C.SWSP
+        assert_eq!(decode(0xd03e).unwrap(), Sw(SType(0x02f12023))); // sw a5, 21(sp)
 
         // C.SDSP
         assert_eq!(decode(0xe022).unwrap(), Sd(SType(0x00813023))); // sd s0, 0(sp)

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -60,7 +60,7 @@ mod tests {
     use crate::{decode, types::*, Instruction::*};
 
     // The bulk of the instructions were obtained by compiling selfie with
-    // an rv64imc enabled gcc compiler. Examples for case were created by hand.
+    // an rv64imc enabled gcc compiler. Examples for edge cases were created by hand.
 
     #[test]
     fn test_quadrant0() {
@@ -143,6 +143,8 @@ mod tests {
     #[test]
     fn test_quadrant1_alu() {
         // C.SRLI unimplemented
+        assert_eq!(decode(0x830d).unwrap(), Srli(IType(0x00375713))); // srli a4, a4, 0x3
+        assert_eq!(decode(0x937d).unwrap(), Srli(IType(0x03f75713))); // srli a4, a4, 0x3f
 
         // C.SRAI
         assert_eq!(decode(0x840d).unwrap(), Srai(IType(0x40345413))); // srai s0, s0, 0x3

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -166,7 +166,8 @@ mod tests {
         // C.AND
         assert_eq!(decode(0x8ff9).unwrap(), And(RType(0x00e7f7b3))); // and a5, a5, a4
 
-        // C.SUBW unimplemented
+        // C.SUBW
+        assert_eq!(decode(0x9f01).unwrap(), Subw(RType(0x4087073b))); // subw a4, a4, s0
 
         // C.ADDW
         assert_eq!(decode(0x9f21).unwrap(), Addw(RType(0x0087073b))); // addw a4, a4, s0

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -168,7 +168,8 @@ mod tests {
 
         // C.SUBW unimplemented
 
-        // C.ADDW unimplemented
+        // C.ADDW
+        assert_eq!(decode(0x9f21).unwrap(), Addw(RType(0x0087073b))); // addw a4, a4, s0
     }
 
     #[test]

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_quadrant1_alu() {
-        // C.SRLI unimplemented
+        // C.SRLI
         assert_eq!(decode(0x830d).unwrap(), Srli(IType(0x00375713))); // srli a4, a4, 0x3
         assert_eq!(decode(0x937d).unwrap(), Srli(IType(0x03f75713))); // srli a4, a4, 0x3f
 
@@ -150,7 +150,10 @@ mod tests {
         assert_eq!(decode(0x840d).unwrap(), Srai(IType(0x40345413))); // srai s0, s0, 0x3
         assert_eq!(decode(0x947d).unwrap(), Srai(IType(0x43f45413))); // srai s0, s0, 0x3f
 
-        // C.ANDI unimplemented
+        // C.ANDI
+        assert_eq!(decode(0x9bf1).unwrap(), Andi(IType(0xffc7f793))); // andi a5, a5, -4
+        assert_eq!(decode(0x9b81).unwrap(), Andi(IType(0xfe07f793))); // andi a5, a5, -32
+        assert_eq!(decode(0x8bfd).unwrap(), Andi(IType(0x01f7f793))); // andi a5, a5, 31
 
         // C.SUB
         assert_eq!(decode(0x8e09).unwrap(), Sub(RType(0x40a60633))); // sub a2, a2, a0

--- a/src/decompress/detail.rs
+++ b/src/decompress/detail.rs
@@ -125,6 +125,7 @@ pub(super) fn decompress_misc_alu(i: u16) -> DecompressionResult {
                 (0, 0b00) => Ok(build_rtype(CrInstr::Sub, rs1_rd, rs1_rd, rs2)),
                 (0, 0b10) => Ok(build_rtype(CrInstr::Or, rs1_rd, rs1_rd, rs2)),
                 (0, 0b11) => Ok(build_rtype(CrInstr::And, rs1_rd, rs1_rd, rs2)),
+                (1, 0b01) => Ok(build_rtype(CrInstr::Addw, rs1_rd, rs1_rd, rs2)),
                 (1, 0b10) => Err(DecodingError::Reserved),
                 (1, 0b11) => Err(DecodingError::Reserved),
                 _ => unreachable!(),

--- a/src/decompress/detail.rs
+++ b/src/decompress/detail.rs
@@ -90,12 +90,19 @@ pub(super) fn decompress_jump(i: u16) -> DecompressionResult {
 
 pub(super) fn decompress_misc_alu(i: u16) -> DecompressionResult {
     match (i >> 10) & 0b11 {
-        0b00 => Err(DecodingError::Unimplemented), // C.SRLI
+        0b00 => {
+            let shamt = get_imm(i, InstrFormat::Ci);
+            let rd_rs1 = 8 + ((i >> 7) & 0b111);
+
+            assert!(shamt != 0, "shamt == 0 is a HINT!");
+
+            Ok(build_itype(CiInstr::Srli, rd_rs1, rd_rs1, shamt))
+        }
         0b01 => {
             let shamt = get_imm(i, InstrFormat::Ci);
             let rd_rs1 = 8 + ((i >> 7) & 0b111);
 
-            assert!(shamt != 0, "shamt == 0 is reserved!");
+            assert!(shamt != 0, "shamt == 0 is a HINT!");
 
             Ok(build_itype(CiInstr::Srai, rd_rs1, rd_rs1, shamt))
         }

--- a/src/decompress/detail.rs
+++ b/src/decompress/detail.rs
@@ -204,12 +204,8 @@ pub(super) fn decompress_store_sp(i: u16, instruction_type: CsInstr) -> Decompre
     let rs2 = (i >> 2) & 0b1_1111;
 
     match instruction_type {
-        CsInstr::Sw => Err(DecodingError::Unimplemented),
-        CsInstr::Sd => {
-            let imm = imm.inv_permute(&[5, 4, 3, 8, 7, 6]);
-
-            Ok(build_stype(CsInstr::Sd, rs1, rs2, imm))
-        }
+        CsInstr::Sw => Ok(build_stype(CsInstr::Sw, rs1, rs2, imm.inv_permute(&[5, 4, 3, 2, 7, 6]))),
+        CsInstr::Sd => Ok(build_stype(CsInstr::Sd, rs1, rs2, imm.inv_permute(&[5, 4, 3, 8, 7, 6])))
     }
 }
 // }}}

--- a/src/decompress/detail.rs
+++ b/src/decompress/detail.rs
@@ -126,6 +126,7 @@ pub(super) fn decompress_misc_alu(i: u16) -> DecompressionResult {
                 (0, 0b10) => Ok(build_rtype(CrInstr::Or, rs1_rd, rs1_rd, rs2)),
                 (0, 0b11) => Ok(build_rtype(CrInstr::And, rs1_rd, rs1_rd, rs2)),
                 (1, 0b01) => Ok(build_rtype(CrInstr::Addw, rs1_rd, rs1_rd, rs2)),
+                (1, 0b00) => Ok(build_rtype(CrInstr::Subw, rs1_rd, rs1_rd, rs2)),
                 (1, 0b10) => Err(DecodingError::Reserved),
                 (1, 0b11) => Err(DecodingError::Reserved),
                 _ => unreachable!(),

--- a/src/decompress/detail.rs
+++ b/src/decompress/detail.rs
@@ -106,7 +106,17 @@ pub(super) fn decompress_misc_alu(i: u16) -> DecompressionResult {
 
             Ok(build_itype(CiInstr::Srai, rd_rs1, rd_rs1, shamt))
         }
-        0b10 => Err(DecodingError::Unimplemented), // C.ANDI
+        0b10 => {
+            let imm = get_imm(i, InstrFormat::Ci);
+            let rd_rs1 = 8 + ((i >> 7) & 0b111);
+
+            Ok(build_itype(
+                CiInstr::Andi,
+                rd_rs1,
+                rd_rs1,
+                sign_extend16(imm, 6),
+            ))
+        }
         0b11 => {
             let rs1_rd = 8 + ((i >> 7) & 0b111);
             let rs2 = 8 + ((i >> 2) & 0b111);

--- a/src/decompress/util.rs
+++ b/src/decompress/util.rs
@@ -5,6 +5,7 @@ pub(super) enum CrInstr {
     Add,
     Or,
     And,
+    Subw,
     Addw,
 }
 
@@ -48,6 +49,7 @@ pub(super) fn build_rtype(instruction_type: CrInstr, rd: u16, rs1: u16, rs2: u16
         CrInstr::Add => mold(0b0000000, rs2, rs1, 0b000, rd, 0b0110011),
         CrInstr::Or => mold(0b0000000, rs2, rs1, 0b110, rd, 0b0110011),
         CrInstr::And => mold(0b0000000, rs2, rs1, 0b111, rd, 0b0110011),
+        CrInstr::Subw => mold(0b0100000, rs2, rs1, 0b000, rd, 0b0111011),
         CrInstr::Addw => mold(0b0000000, rs2, rs1, 0b000, rd, 0b0111011),
     }
 }

--- a/src/decompress/util.rs
+++ b/src/decompress/util.rs
@@ -14,6 +14,7 @@ pub(super) enum CiInstr {
     Ld,
     Jalr,
     Slli,
+    Srli,
     Srai,
 }
 
@@ -65,6 +66,7 @@ pub(super) fn build_itype(instruction_type: CiInstr, rd: u16, rs1: u16, imm: u16
         CiInstr::Jalr => mold(imm, rs1, 0b000, rd, 0b1100111),
         CiInstr::Slli => mold(imm, rs1, 0b001, rd, 0b0010011),
         CiInstr::Srai => mold((0b0100000 << 5) | imm, rs1, 0b101, rd, 0b0010011),
+        CiInstr::Srli => mold(imm, rs1, 0b101, rd, 0b0010011),
     }
 }
 
@@ -75,7 +77,6 @@ pub(super) fn build_btype(instruction_type: CbInstr, rs1: u16, imm: u16) -> u32 
 
         let imm: u32 = imm.permute(&[12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 11]).into();
 
-        // FIXME: check if this is correct!
         ((imm >> 5) << 25)
             | (rs2 << 20)
             | (rs1 << 15)

--- a/src/decompress/util.rs
+++ b/src/decompress/util.rs
@@ -5,6 +5,7 @@ pub(super) enum CrInstr {
     Add,
     Or,
     And,
+    Addw,
 }
 
 pub(super) enum CiInstr {
@@ -47,6 +48,7 @@ pub(super) fn build_rtype(instruction_type: CrInstr, rd: u16, rs1: u16, rs2: u16
         CrInstr::Add => mold(0b0000000, rs2, rs1, 0b000, rd, 0b0110011),
         CrInstr::Or => mold(0b0000000, rs2, rs1, 0b110, rd, 0b0110011),
         CrInstr::And => mold(0b0000000, rs2, rs1, 0b111, rd, 0b0110011),
+        CrInstr::Addw => mold(0b0000000, rs2, rs1, 0b000, rd, 0b0111011),
     }
 }
 

--- a/src/decompress/util.rs
+++ b/src/decompress/util.rs
@@ -10,6 +10,7 @@ pub(super) enum CrInstr {
 pub(super) enum CiInstr {
     Addi,
     Addiw,
+    Andi,
     Lw,
     Ld,
     Jalr,
@@ -61,6 +62,7 @@ pub(super) fn build_itype(instruction_type: CiInstr, rd: u16, rs1: u16, imm: u16
     match instruction_type {
         CiInstr::Addi => mold(imm, rs1, 0b000, rd, 0b0010011),
         CiInstr::Addiw => mold(imm, rs1, 0b000, rd, 0b0011011),
+        CiInstr::Andi => mold(imm, rs1, 0b111, rd, 0b0010011),
         CiInstr::Lw => mold(imm, rs1, 0b010, rd, 0b0000011),
         CiInstr::Ld => mold(imm, rs1, 0b011, rd, 0b0000011),
         CiInstr::Jalr => mold(imm, rs1, 0b000, rd, 0b1100111),


### PR DESCRIPTION
Add compressed instructions necessary to disassemble the binary that `riscv-gcc` generates from `selfie.c` (see https://github.com/cksystemsteaching/selfie/pull/346).